### PR TITLE
display data more accurately

### DIFF
--- a/apps/web/src/components/charts/time-series-chart.tsx
+++ b/apps/web/src/components/charts/time-series-chart.tsx
@@ -198,9 +198,16 @@ export function InstanceTimeSeriesEcharts({
         const scatterSeries = {
           ...baseSeries,
           type: "scatter",
-        } as const satisfies echarts.SeriesOption;
+          symbol: "circle",
+          symbolSize: 6,
+          selectedMode: "single",
+          emphasis: {
+            focus: "self",
+            scale: 1.5,
+          },
+        } satisfies echarts.SeriesOption;
 
-        return timeRange.windowMinutes > 0 ? lineSeries : scatterSeries;
+        return timeRange.windowMinutes > 14 ? lineSeries : scatterSeries;
       });
     },
   );

--- a/apps/web/src/components/time-series-settings-picker.tsx
+++ b/apps/web/src/components/time-series-settings-picker.tsx
@@ -55,7 +55,7 @@ export function TimeSeriesSettingsPicker({
           { label: "every event", value: "0" },
           { label: "1 minute", value: "1" },
           { label: "5 minutes", value: "5" },
-          { label: "10 minutes", value: "10" },
+          { label: "15 minutes", value: "15" },
           { label: "30 minutes", value: "30" },
           { label: "1 hour", value: "60" },
           { label: "6 hours", value: "360" },

--- a/apps/web/src/constants.ts
+++ b/apps/web/src/constants.ts
@@ -5,7 +5,7 @@ export const instanceCountsAsActiveDays = 30;
 export const getTimeRangeDefaults = () => ({
   start: +new Date() - 7 * 24 * 60 * 60 * 1000,
   end: +new Date(),
-  windowMinutes: 10,
+  windowMinutes: 15,
 });
 
 const chartColors = [

--- a/apps/web/src/orpc/timeSeries/router.ts
+++ b/apps/web/src/orpc/timeSeries/router.ts
@@ -176,10 +176,7 @@ export const timeSeriesRouter = {
         }
         tables
           .get(row.table)!
-          .data.push([
-            new Date(row._time).getTime(),
-            row._value ? Number(row._value) : null,
-          ]);
+          .data.push([new Date(row._time).getTime(), row._value]);
       });
 
       return Array.from(tables.values());


### PR DESCRIPTION
- set default granularity to 15mins

- for everything below 15mins, use scatter plot instead

- render 0 values #11